### PR TITLE
Modify harness CMake file to allow installation to parent 

### DIFF
--- a/harness/CMakeLists.txt
+++ b/harness/CMakeLists.txt
@@ -9,6 +9,7 @@ if (${JANICE_WITH_EVAL_HARNESS} AND (JANICE_IO_IMPLEMENTATION) AND (JANICE_IMPLE
   include_directories(include)
 
   set(UTILS
+      janice_create_gallery.cpp
       janice_detect.cpp
       janice_enroll_media.cpp
       janice_enroll_detections.cpp

--- a/harness/CMakeLists.txt
+++ b/harness/CMakeLists.txt
@@ -15,6 +15,7 @@ if (${JANICE_WITH_EVAL_HARNESS} AND (JANICE_IO_IMPLEMENTATION) AND (JANICE_IMPLE
       janice_search.cpp
       janice_cluster_templates.cpp
       janice_cluster_media.cpp
+      janice_verify.cpp
       )
 
   # Loop over the utils, rather than having a separate rule for each.

--- a/harness/CMakeLists.txt
+++ b/harness/CMakeLists.txt
@@ -8,28 +8,23 @@ if (${JANICE_WITH_EVAL_HARNESS} AND (JANICE_IO_IMPLEMENTATION) AND (JANICE_IMPLE
   include_directories(../implementations/opencv_io)
   include_directories(include)
 
-  # Detection
-  add_executable(janice_detect janice_detect.cpp)
-  target_link_libraries(janice_detect ${JANICE_IO_IMPLEMENTATION} ${JANICE_IMPLEMENTATION})
+  set(UTILS
+      janice_detect.cpp
+      janice_enroll_media.cpp
+      janice_enroll_detections.cpp
+      janice_search.cpp
+      janice_cluster_templates.cpp
+      janice_cluster_media.cpp
+      )
 
-  # Enroll from media
-  add_executable(janice_enroll_media janice_enroll_media.cpp)
-  target_link_libraries(janice_enroll_media ${JANICE_IO_IMPLEMENTATION} ${JANICE_IMPLEMENTATION})
-
-  # Enroll from detections
-  add_executable(janice_enroll_detections janice_enroll_detections.cpp)
-  target_link_libraries(janice_enroll_detections ${JANICE_IO_IMPLEMENTATION} ${JANICE_IMPLEMENTATION})
-
-  # Search
-  add_executable(janice_search janice_search.cpp)
-  target_link_libraries(janice_search ${JANICE_IO_IMPLEMENTATION} ${JANICE_IMPLEMENTATION})
-
-  # Cluster pre-done template
-  add_executable(janice_cluster_templates janice_cluster_templates.cpp)
-  target_link_libraries(janice_cluster_templates ${JANICE_IO_IMPLEMENTATION} ${JANICE_IMPLEMENTATION})
-
-  # Do feature extractiOn + clustering from meida
-  add_executable(janice_cluster_media janice_cluster_media.cpp)
-  target_link_libraries(janice_cluster_media ${JANICE_IO_IMPLEMENTATION} ${JANICE_IMPLEMENTATION})
-
-endif()
+  # Loop over the utils, rather than having a separate rule for each.
+  # If caller has defined JANICE_EVAL_HARNESS_INSTALL, add an install step for each one.
+  foreach(UTIL ${UTILS})
+    get_filename_component(UTIL_NAME ${UTIL} NAME_WE)
+    add_executable(${UTIL_NAME} ${UTIL})
+    target_link_libraries(${UTIL_NAME} ${JANICE_IO_IMPLEMENTATION} ${JANICE_IMPLEMENTATION})
+    if (DEFINED JANICE_EVAL_HARNESS_INSTALL)
+      install(TARGETS ${UTIL_NAME} RUNTIME DESTINATION ${JANICE_EVAL_HARNESS_INSTALL})
+    endif()
+  endforeach()
+ endif()

--- a/harness/include/janice_harness.h
+++ b/harness/include/janice_harness.h
@@ -9,6 +9,8 @@
 #include <vector>
 #include <thread>
 #include <cstring>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #define JANICE_ASSERT(func)                 \
 {                                           \
@@ -29,6 +31,11 @@ inline std::string get_ext(const std::string& filename)
     if (idx != std::string::npos)
         return filename.substr(idx + 1);
     return "";
+}
+
+inline bool file_exists(const std::string &filename)
+{
+  return (access(filename.c_str(), F_OK) != -1);
 }
 
 inline bool parse_optional_args(int argc, char** argv, int min_args, int /*max_args*/, std::string& algorithm, int& num_threads, int& gpu)

--- a/harness/include/janice_harness.h
+++ b/harness/include/janice_harness.h
@@ -39,13 +39,19 @@ inline bool parse_optional_args(int argc, char** argv, int min_args, int /*max_a
 
     int i;
     for (i = 0; i < (argc - min_args); ++i) {
-        if      (strcmp(argv[min_args + i], "-algorithm") == 0) algorithm   = argv[min_args + (++i)];
-        else if (strcmp(argv[min_args + i], "-threads")   == 0) num_threads = atoi(argv[min_args + (++i)]);
-        else if (strcmp(argv[min_args + i], "-gpu")       == 0) gpu         = atoi(argv[min_args + (++i)]);
-        else {
-            printf("Unrecognized flag: %s\n", argv[min_args + i]);
-            return false;
-        }
+      if (strcmp(argv[min_args + i], "-algorithm") == 0) {
+        algorithm   = argv[min_args + (++i)];
+      }
+      else if (strcmp(argv[min_args + i], "-threads") == 0) {
+        num_threads = atoi(argv[min_args + (++i)]);
+      }
+      else if (strcmp(argv[min_args + i], "-gpu") == 0) {
+        gpu = atoi(argv[min_args + (++i)]);
+      }
+      else {
+        printf("Unrecognized flag: %s\n", argv[min_args + i]);
+        return false;
+      }
     }
 
     return true;

--- a/harness/include/janice_harness.h
+++ b/harness/include/janice_harness.h
@@ -12,13 +12,16 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#define STRINGIFY2(x) #x
+#define STRINGIFY(x) STRINGIFY2(x)
 #define JANICE_ASSERT(func)                 \
 {                                           \
     JaniceError rc = (func);                \
     if (rc != JANICE_SUCCESS) {             \
-        printf("Janice function failed!\n"  \
+        printf("Janice function %s failed!\n"  \
                "    Error: %s\n"            \
                "    Location: %s:%d\n",     \
+               STRINGIFY(func),             \
                janice_error_to_string(rc),  \
                __FILE__, __LINE__);         \
         exit(EXIT_FAILURE);                 \

--- a/harness/janice_create_gallery.cpp
+++ b/harness/janice_create_gallery.cpp
@@ -72,6 +72,8 @@ int main(int argc, char* argv[])
     JANICE_ASSERT(janice_free_template(&tmpl));
     subject_id_lut[template_id] = subject_id;
   }
+
+  JANICE_ASSERT(janice_gallery_prepare(gallery));
   
   JANICE_ASSERT(janice_write_gallery(gallery, gallery_file.c_str()));
   

--- a/harness/janice_create_gallery.cpp
+++ b/harness/janice_create_gallery.cpp
@@ -1,0 +1,83 @@
+#include <janice.h>
+#include <janice_io_opencv.h>
+#include <janice_harness.h>
+
+#include <fast-cpp-csv-parser/csv.h>
+
+#include <unordered_map>
+
+void print_usage()
+{
+  printf("Usage: janice_create_gallery sdk_path temp_path templates_list_file gallery_file [-algorithm <algorithm>] [-threads <int>] [-gpu <int>]\n");
+}
+
+int main(int argc, char* argv[])
+{
+  const int min_args = 5;
+  const int max_args = 11;
+
+  if (argc < min_args || argc > max_args) {
+    print_usage();
+    exit(EXIT_FAILURE);
+  }
+
+  const std::string sdk_path       = argv[1];
+  const std::string temp_path      = argv[2];
+  const std::string templates_list_file = argv[3];
+  const std::string gallery_file   = argv[4];
+
+  std::string algorithm;
+  int num_threads;
+  int gpu;
+  if (!parse_optional_args(argc, argv, min_args, max_args, algorithm, num_threads, gpu))
+    exit(EXIT_FAILURE);
+
+  // Check input
+  if (get_ext(templates_list_file) != "csv") {
+    printf("templates_list_file must be \".csv\" format.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // Initialize the API
+  // TODO: Right now we only allow a single GPU to be used
+  JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
+
+  JaniceError res;
+
+  JaniceGallery gallery = nullptr;
+
+  // Create an empty gallery
+  JaniceTemplates tmpls;
+  tmpls.tmpls = nullptr;
+  tmpls.length = 0;
+  
+  JaniceTemplateIds ids;
+  ids.ids = nullptr;
+  ids.length = 0;
+  JANICE_ASSERT(janice_create_gallery(tmpls, ids, &gallery));
+
+  // Load the gallery
+  io::CSVReader<3> gallery_metadata(templates_list_file);
+  gallery_metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID");
+  
+  std::unordered_map<int, int> subject_id_lut;
+  
+  // Load template into a gallery
+  std::string filename;
+  int template_id, subject_id;
+  while (gallery_metadata.read_row(filename, template_id, subject_id)) {
+    JaniceTemplate tmpl;
+    JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl));
+    JANICE_ASSERT(janice_gallery_insert(gallery, tmpl, template_id));
+    JANICE_ASSERT(janice_free_template(&tmpl));
+    subject_id_lut[template_id] = subject_id;
+  }
+  
+  JANICE_ASSERT(janice_write_gallery(gallery, gallery_file.c_str()));
+  
+  JANICE_ASSERT(janice_free_gallery(&gallery));
+  
+  JANICE_ASSERT(janice_finalize());
+  
+  return 0;
+}

--- a/harness/janice_detect.cpp
+++ b/harness/janice_detect.cpp
@@ -63,22 +63,21 @@ int main(int argc, char* argv[])
     JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context))
 
     // Parse the images file
-    io::CSVReader<1> *images = new io::CSVReader<1>(images_file);
-    images->read_header(io::ignore_extra_column, "FILENAME");
+    io::CSVReader<1> images(images_file);
+    images.read_header(io::ignore_extra_column, "FILENAME");
 
     std::vector<std::string> filenames;
     std::vector<JaniceMediaIterator> media;
 
     // Load filenames into a vector
     std::string filename;
-    while (images->read_row(filename)) {
+    while (images.read_row(filename)) {
         JaniceMediaIterator it;
         JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &it))
 
         filenames.push_back(filename);
         media.push_back(it);
     }
-    delete images;
 
     // Convert the vector into a C-style struct
     JaniceMediaIterators media_list;

--- a/harness/janice_detect.cpp
+++ b/harness/janice_detect.cpp
@@ -63,21 +63,22 @@ int main(int argc, char* argv[])
     JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context))
 
     // Parse the images file
-    io::CSVReader<1> images(images_file);
-    images.read_header(io::ignore_extra_column, "file");
+    io::CSVReader<1> *images = new io::CSVReader<1>(images_file);
+    images->read_header(io::ignore_extra_column, "FILENAME");
 
     std::vector<std::string> filenames;
     std::vector<JaniceMediaIterator> media;
 
     // Load filenames into a vector
     std::string filename;
-    while (images.read_row(filename)) {
+    while (images->read_row(filename)) {
         JaniceMediaIterator it;
         JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &it))
 
         filenames.push_back(filename);
         media.push_back(it);
     }
+    delete images;
 
     // Convert the vector into a C-style struct
     JaniceMediaIterators media_list;

--- a/harness/janice_detect.cpp
+++ b/harness/janice_detect.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
     
     // Write the detection files to disk
     FILE* output = fopen(output_file.c_str(), "w+");
-    fprintf(output, "file,frame,Face_X,Face_Y,Face_Width,Face_Height,Confidence\n");
+    fprintf(output, "FILENAME,FRAME,FACE_X,FACE_Y,FACE_WIDTH,FACE_HEIGHT,CONFIDENCE\n");
 
     for (size_t i = 0; i < detections_group.length; ++i) {
         JaniceDetections detections = detections_group.group[i];

--- a/harness/janice_enroll_detections.cpp
+++ b/harness/janice_enroll_detections.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
 
     // Parse the metadata file
     io::CSVReader<7> metadata(input_file);
-    metadata.read_header(io::ignore_extra_column, "file", "templateId", "subjectId", "Face_X", "Face_Y", "Face_Width", "Face_Height");
+    metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID", "FACE_X", "FACE_Y", "FACE_WIDTH", "FACE_HEIGHT");
 
     std::unordered_map<int, std::vector<JaniceDetection>> detections_lut;
     std::unordered_map<int, int> subject_id_lut;

--- a/harness/janice_enroll_detections.cpp
+++ b/harness/janice_enroll_detections.cpp
@@ -33,7 +33,8 @@ int main(int argc, char* argv[])
     std::string output_path = argv[6];
 
     std::string algorithm;
-    int num_threads, gpu;
+    int num_threads = 0;
+    int gpu = 0;
     if (!parse_optional_args(argc, argv, min_args, max_args, algorithm, num_threads, gpu))
         exit(EXIT_FAILURE);
     

--- a/harness/janice_enroll_detections.cpp
+++ b/harness/janice_enroll_detections.cpp
@@ -126,6 +126,8 @@ int main(int argc, char* argv[])
         exit(EXIT_FAILURE);
     }
 
+    janice_clear_detections_group(&detections_group);
+#if 0
     // Clear the detections
     for (size_t i = 0; i < detections_group.length; ++i) {
         for (size_t j = 0; j < detections_group.group[i].length; ++j)
@@ -133,6 +135,7 @@ int main(int argc, char* argv[])
         delete[] detections_group.group[i].detections;
     }
     delete[] detections_group.group;
+#endif
 
     // Write the templates to disk
     struct stat stat_buf;

--- a/harness/janice_enroll_detections.cpp
+++ b/harness/janice_enroll_detections.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
 
     // Initialize the API
     // TODO: Right now we only allow a single GPU to be used
-    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1))
+    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
 
     // Unused defaults for context parameters
     JaniceDetectionPolicy policy = JaniceDetectAll;
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
     double hint = 0;
 
     JaniceContext context = nullptr;
-    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context))
+    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context));
 
     // Parse the metadata file
     io::CSVReader<7> metadata(input_file);
@@ -82,10 +82,10 @@ int main(int argc, char* argv[])
     JaniceRect rect;
     while (metadata.read_row(filename, template_id, subject_id, rect.x, rect.y, rect.width, rect.height)) {
         JaniceMediaIterator media;
-        JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &media))
+        JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &media));
 
         JaniceDetection detection;
-        JANICE_ASSERT(janice_create_detection_from_rect(media, rect, 0, &detection))
+        JANICE_ASSERT(janice_create_detection_from_rect(media, rect, 0, &detection));
 
         if (detections_lut.find(template_id) == detections_lut.end()) {
             detections_lut.insert(std::make_pair(template_id, std::vector<JaniceDetection>{detection}));
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
 
         subject_id_lut[template_id] = subject_id;
 
-        JANICE_ASSERT(media->free(&media))
+        JANICE_ASSERT(media->free(&media));
     }
 
     // Convert the LUT into a detections group object
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
 
     // Run batch enrollment
     JaniceTemplates tmpls;
-    JANICE_ASSERT(janice_enroll_from_detections_batch(detections_group, context, &tmpls))
+    JANICE_ASSERT(janice_enroll_from_detections_batch(detections_group, context, &tmpls));
 
     // Assert we got the correct number of templates (1 list for each media)
     if (tmpls.length != detections_group.length) {
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
     // Clear the detections
     for (size_t i = 0; i < detections_group.length; ++i) {
         for (size_t j = 0; j < detections_group.group[i].length; ++j)
-            JANICE_ASSERT(janice_free_detection(&detections_group.group[i].detections[j]));
+          JANICE_ASSERT(janice_free_detection(&detections_group.group[i].detections[j]));
         delete[] detections_group.group[i].detections;
     }
     delete[] detections_group.group;
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
 
     for (size_t i = 0; i < tmpls.length; ++i) {
         std::string tmpl_file = output_path + "/" + std::to_string(template_ids[i]) + ".tmpl";
-        JANICE_ASSERT(janice_write_template(tmpls.tmpls[i], tmpl_file.c_str()))
+        JANICE_ASSERT(janice_write_template(tmpls.tmpls[i], tmpl_file.c_str()));
 
         fprintf(output, "%s,%d,%d\n", tmpl_file.c_str(), template_ids[i], subject_id_lut[template_ids[i]]);
     }
@@ -169,10 +169,10 @@ int main(int argc, char* argv[])
     fclose(output);
 
     // Free the templates
-    JANICE_ASSERT(janice_clear_templates(&tmpls))
+    JANICE_ASSERT(janice_clear_templates(&tmpls));
 
     // Finalize the API
-    JANICE_ASSERT(janice_finalize())
+    JANICE_ASSERT(janice_finalize());
 
     return 0;
 }

--- a/harness/janice_search.cpp
+++ b/harness/janice_search.cpp
@@ -8,127 +8,141 @@
 
 void print_usage()
 {
-    printf("Usage: janice_search sdk_path temp_path probe_file gallery_file threshold num_returns candidate_list [-algorithm <algorithm>] [-threads <int>] [-gpu <int>]\n");
+  printf("Usage: janice_search sdk_path temp_path probe_file gallery_file threshold num_returns candidate_list [-algorithm <algorithm>] [-threads <int>] [-gpu <int>]\n");
 }
 
 int main(int argc, char* argv[])
 {
-    const int min_args = 8;
-    const int max_args = 14;
+  const int min_args = 8;
+  const int max_args = 14;
 
-    if (argc < min_args || argc > max_args) {
-        print_usage();
-        exit(EXIT_FAILURE);
+  if (argc < min_args || argc > max_args) {
+    print_usage();
+    exit(EXIT_FAILURE);
+  }
+
+  const std::string sdk_path       = argv[1];
+  const std::string temp_path      = argv[2];
+  const std::string probe_file     = argv[3];
+  const std::string gallery_file   = argv[4];
+  const float threshold            = atof(argv[5]);
+  const uint32_t num_returns       = atol(argv[6]);
+  const std::string cand_list_file = argv[7];
+
+  bool gallery_exists = false;
+
+  std::string algorithm;
+  int num_threads;
+  int gpu;
+  if (!parse_optional_args(argc, argv, min_args, max_args, algorithm, num_threads, gpu))
+    exit(EXIT_FAILURE);
+
+  // Check input
+  if (get_ext(probe_file) != "csv") {
+    printf("probe_file must be \".csv\" format.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  if (get_ext(gallery_file) != "csv") {
+    if (file_exists(gallery_file)) {
+      gallery_exists = true;
     }
-
-    const std::string sdk_path       = argv[1];
-    const std::string temp_path      = argv[2];
-    const std::string probe_file     = argv[3];
-    const std::string gallery_file   = argv[4];
-    const float threshold            = atof(argv[5]);
-    const uint32_t num_returns       = atol(argv[6]);
-    const std::string cand_list_file = argv[7];
-
-    std::string algorithm;
-    int num_threads;
-    int gpu;
-    if (!parse_optional_args(argc, argv, min_args, max_args, algorithm, num_threads, gpu))
-        exit(EXIT_FAILURE);
-
-    // Check input
-    if (get_ext(probe_file) != "csv") {
-        printf("probe_file must be \".csv\" format.\n");
-        exit(EXIT_FAILURE);
+    else {
+      printf("gallery_file must exist.\n");
+      exit(EXIT_FAILURE);
     }
+  }
 
-    if (get_ext(gallery_file) != "csv") {
-        printf("gallery_file must be \".csv\" format.\n");
-        exit(EXIT_FAILURE);
+  // Initialize the API
+  // TODO: Right now we only allow a single GPU to be used
+  JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
+
+  JaniceError res;
+  JaniceDetectionPolicy policy = JaniceDetectAll; // This is ignored
+  uint32_t min_object_size = 0;
+  JaniceEnrollmentType role = Janice1NProbe; // This is ignored
+  double hint = 0.0;
+
+  JaniceContext context = nullptr;
+  JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, num_returns, hint, &context));
+
+  JaniceGallery gallery = nullptr;
+  // taa: Allow this to work with an existing gallery file, rather than always creating one from the template list.
+  if (gallery_exists) {
+    JANICE_ASSERT(janice_read_gallery(gallery_file.c_str(), &gallery));
+  }
+  else { 
+    // Create an empty gallery
+    JaniceTemplates tmpls;
+    tmpls.tmpls = nullptr;
+    tmpls.length = 0;
+    
+    JaniceTemplateIds ids;
+    ids.ids = nullptr;
+    ids.length = 0;
+    JANICE_ASSERT(janice_create_gallery(tmpls, ids, &gallery));
+  }
+
+  // Load the gallery
+  io::CSVReader<3> gallery_metadata(gallery_file);
+  gallery_metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID");
+  
+  std::unordered_map<int, int> subject_id_lut;
+  
+  // Load template into a gallery
+  std::string filename;
+  int template_id, subject_id;
+  while (gallery_metadata.read_row(filename, template_id, subject_id)) {
+    JaniceTemplate tmpl;
+    if (! gallery_exists) {
+      JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl));
+      JANICE_ASSERT(janice_gallery_insert(gallery, tmpl, template_id));
+      JANICE_ASSERT(janice_free_template(&tmpl));
     }
-
-    // Initialize the API
-    // TODO: Right now we only allow a single GPU to be used
-    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1))
-
-    JaniceDetectionPolicy policy = JaniceDetectAll; // This is ignored
-    uint32_t min_object_size = 0;
-    JaniceEnrollmentType role = Janice1NProbe; // This is ignored
-    double hint = 0.0;
-
-    JaniceContext context = nullptr;
-    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, num_returns, hint, &context))
-
-    JaniceGallery gallery = nullptr;
-    { // Create an empty gallery
-        JaniceTemplates tmpls;
-        tmpls.tmpls = nullptr;
-        tmpls.length = 0;
-
-        JaniceTemplateIds ids;
-        ids.ids = nullptr;
-        ids.length = 0;
-        JANICE_ASSERT(janice_create_gallery(tmpls, ids, &gallery))
+      
+    subject_id_lut[template_id] = subject_id;
+      
+  }
+  
+  // Keep
+  const uint32_t k = num_returns != 0 ? std::min(num_returns, (uint32_t) subject_id_lut.size()) : (uint32_t) subject_id_lut.size();
+  
+  // Open the candidate list file
+  printf("cand_list_file: %s\n", cand_list_file.c_str());
+  FILE* cand_list = fopen(cand_list_file.c_str(), "w+");
+  fprintf(cand_list, "0");
+  for (uint32_t i = 0; i < k; ++i)
+    fprintf(cand_list, ",%u", i);
+  fprintf(cand_list, "\n");
+  
+  // Parse the probe file
+  io::CSVReader<3> probe_metadata(probe_file);
+  probe_metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID");
+  
+  while (probe_metadata.read_row(filename, template_id, subject_id)) {
+    JaniceTemplate tmpl;
+    JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl));
+    
+    JaniceSimilarities similarities;
+    JaniceTemplateIds ids;
+    JANICE_ASSERT(janice_search(tmpl, gallery, context, &similarities, &ids));
+    
+    fprintf(cand_list, "%d", template_id);
+    for (size_t i = 0; i < similarities.length; ++i) {
+      std::string label = (subject_id_lut[ids.ids[i]] == subject_id ? "G" : "I");
+      fprintf(cand_list, ",%f(%s)", similarities.similarities[i], label.c_str());
     }
-
-    // Load the gallery
-    io::CSVReader<3> gallery_metadata(gallery_file);
-    gallery_metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID");
-
-    std::unordered_map<int, int> subject_id_lut;
-
-    // Load template into a gallery
-    std::string filename;
-    int template_id, subject_id;
-    while (gallery_metadata.read_row(filename, template_id, subject_id)) {
-        JaniceTemplate tmpl;
-        JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl))
-
-        JANICE_ASSERT(janice_gallery_insert(gallery, tmpl, template_id))
-
-        subject_id_lut[template_id] = subject_id;
-
-        JANICE_ASSERT(janice_free_template(&tmpl))
-    }
-
-    // Keep
-    const uint32_t k = num_returns != 0 ? std::min(num_returns, (uint32_t) subject_id_lut.size()) : (uint32_t) subject_id_lut.size();
-
-    // Open the candidate list file
-    printf("cand_list_file: %s\n", cand_list_file.c_str());
-    FILE* cand_list = fopen(cand_list_file.c_str(), "w+");
-    fprintf(cand_list, "0");
-    for (uint32_t i = 0; i < k; ++i)
-        fprintf(cand_list, ",%u", i);
     fprintf(cand_list, "\n");
-
-    // Parse the probe file
-    io::CSVReader<3> probe_metadata(probe_file);
-    probe_metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID");
-
-    while (probe_metadata.read_row(filename, template_id, subject_id)) {
-        JaniceTemplate tmpl;
-        JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl))
-
-        JaniceSimilarities similarities;
-        JaniceTemplateIds ids;
-        JANICE_ASSERT(janice_search(tmpl, gallery, context, &similarities, &ids))
-
-        fprintf(cand_list, "%d", template_id);
-        for (size_t i = 0; i < similarities.length; ++i) {
-            std::string label = (subject_id_lut[ids.ids[i]] == subject_id ? "G" : "I");
-            fprintf(cand_list, ",%f(%s)", similarities.similarities[i], label.c_str());
-        }
-        fprintf(cand_list, "\n");
-
-        JANICE_ASSERT(janice_clear_similarities(&similarities))
-        JANICE_ASSERT(janice_clear_template_ids(&ids))
-        JANICE_ASSERT(janice_free_template(&tmpl))
-    }
-
-    JANICE_ASSERT(janice_free_gallery(&gallery))
-    JANICE_ASSERT(janice_free_context(&context))
-
-    JANICE_ASSERT(janice_finalize())
-
-    return 0;
+    
+    JANICE_ASSERT(janice_clear_similarities(&similarities));
+    JANICE_ASSERT(janice_clear_template_ids(&ids));
+    JANICE_ASSERT(janice_free_template(&tmpl));
+  }
+  
+  JANICE_ASSERT(janice_free_gallery(&gallery));
+  JANICE_ASSERT(janice_free_context(&context));
+  
+  JANICE_ASSERT(janice_finalize());
+  
+  return 0;
 }

--- a/harness/janice_search.cpp
+++ b/harness/janice_search.cpp
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
 
     // Load the gallery
     io::CSVReader<3> gallery_metadata(gallery_file);
-    gallery_metadata.read_header(io::ignore_extra_column, "file", "templateId", "subjectId");
+    gallery_metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID");
 
     std::unordered_map<int, int> subject_id_lut;
 
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
 
     // Parse the probe file
     io::CSVReader<3> probe_metadata(probe_file);
-    probe_metadata.read_header(io::ignore_extra_column, "file", "templateId", "subjectId");
+    probe_metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID");
 
     while (probe_metadata.read_row(filename, template_id, subject_id)) {
         JaniceTemplate tmpl;

--- a/harness/janice_search.cpp
+++ b/harness/janice_search.cpp
@@ -8,141 +8,127 @@
 
 void print_usage()
 {
-  printf("Usage: janice_search sdk_path temp_path probe_file gallery_file threshold num_returns candidate_list [-algorithm <algorithm>] [-threads <int>] [-gpu <int>]\n");
+    printf("Usage: janice_search sdk_path temp_path probe_file gallery_file threshold num_returns candidate_list [-algorithm <algorithm>] [-threads <int>] [-gpu <int>]\n");
 }
 
 int main(int argc, char* argv[])
 {
-  const int min_args = 8;
-  const int max_args = 14;
+    const int min_args = 8;
+    const int max_args = 14;
 
-  if (argc < min_args || argc > max_args) {
-    print_usage();
-    exit(EXIT_FAILURE);
-  }
-
-  const std::string sdk_path       = argv[1];
-  const std::string temp_path      = argv[2];
-  const std::string probe_file     = argv[3];
-  const std::string gallery_file   = argv[4];
-  const float threshold            = atof(argv[5]);
-  const uint32_t num_returns       = atol(argv[6]);
-  const std::string cand_list_file = argv[7];
-
-  bool gallery_exists = false;
-
-  std::string algorithm;
-  int num_threads;
-  int gpu;
-  if (!parse_optional_args(argc, argv, min_args, max_args, algorithm, num_threads, gpu))
-    exit(EXIT_FAILURE);
-
-  // Check input
-  if (get_ext(probe_file) != "csv") {
-    printf("probe_file must be \".csv\" format.\n");
-    exit(EXIT_FAILURE);
-  }
-
-  if (get_ext(gallery_file) != "csv") {
-    if (file_exists(gallery_file)) {
-      gallery_exists = true;
+    if (argc < min_args || argc > max_args) {
+        print_usage();
+        exit(EXIT_FAILURE);
     }
-    else {
-      printf("gallery_file must exist.\n");
-      exit(EXIT_FAILURE);
+
+    const std::string sdk_path       = argv[1];
+    const std::string temp_path      = argv[2];
+    const std::string probe_file     = argv[3];
+    const std::string gallery_file   = argv[4];
+    const float threshold            = atof(argv[5]);
+    const uint32_t num_returns       = atol(argv[6]);
+    const std::string cand_list_file = argv[7];
+
+    std::string algorithm;
+    int num_threads;
+    int gpu;
+    if (!parse_optional_args(argc, argv, min_args, max_args, algorithm, num_threads, gpu))
+        exit(EXIT_FAILURE);
+
+    // Check input
+    if (get_ext(probe_file) != "csv") {
+        printf("probe_file must be \".csv\" format.\n");
+        exit(EXIT_FAILURE);
     }
-  }
 
-  // Initialize the API
-  // TODO: Right now we only allow a single GPU to be used
-  JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
-
-  JaniceError res;
-  JaniceDetectionPolicy policy = JaniceDetectAll; // This is ignored
-  uint32_t min_object_size = 0;
-  JaniceEnrollmentType role = Janice1NProbe; // This is ignored
-  double hint = 0.0;
-
-  JaniceContext context = nullptr;
-  JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, num_returns, hint, &context));
-
-  JaniceGallery gallery = nullptr;
-  // taa: Allow this to work with an existing gallery file, rather than always creating one from the template list.
-  if (gallery_exists) {
-    JANICE_ASSERT(janice_read_gallery(gallery_file.c_str(), &gallery));
-  }
-  else { 
-    // Create an empty gallery
-    JaniceTemplates tmpls;
-    tmpls.tmpls = nullptr;
-    tmpls.length = 0;
-    
-    JaniceTemplateIds ids;
-    ids.ids = nullptr;
-    ids.length = 0;
-    JANICE_ASSERT(janice_create_gallery(tmpls, ids, &gallery));
-  }
-
-  // Load the gallery
-  io::CSVReader<3> gallery_metadata(gallery_file);
-  gallery_metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID");
-  
-  std::unordered_map<int, int> subject_id_lut;
-  
-  // Load template into a gallery
-  std::string filename;
-  int template_id, subject_id;
-  while (gallery_metadata.read_row(filename, template_id, subject_id)) {
-    JaniceTemplate tmpl;
-    if (! gallery_exists) {
-      JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl));
-      JANICE_ASSERT(janice_gallery_insert(gallery, tmpl, template_id));
-      JANICE_ASSERT(janice_free_template(&tmpl));
+    if (get_ext(gallery_file) != "csv") {
+        printf("gallery_file must be \".csv\" format.\n");
+        exit(EXIT_FAILURE);
     }
-      
-    subject_id_lut[template_id] = subject_id;
-      
-  }
-  
-  // Keep
-  const uint32_t k = num_returns != 0 ? std::min(num_returns, (uint32_t) subject_id_lut.size()) : (uint32_t) subject_id_lut.size();
-  
-  // Open the candidate list file
-  printf("cand_list_file: %s\n", cand_list_file.c_str());
-  FILE* cand_list = fopen(cand_list_file.c_str(), "w+");
-  fprintf(cand_list, "0");
-  for (uint32_t i = 0; i < k; ++i)
-    fprintf(cand_list, ",%u", i);
-  fprintf(cand_list, "\n");
-  
-  // Parse the probe file
-  io::CSVReader<3> probe_metadata(probe_file);
-  probe_metadata.read_header(io::ignore_extra_column, "FILENAME", "TEMPLATE_ID", "SUBJECT_ID");
-  
-  while (probe_metadata.read_row(filename, template_id, subject_id)) {
-    JaniceTemplate tmpl;
-    JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl));
-    
-    JaniceSimilarities similarities;
-    JaniceTemplateIds ids;
-    JANICE_ASSERT(janice_search(tmpl, gallery, context, &similarities, &ids));
-    
-    fprintf(cand_list, "%d", template_id);
-    for (size_t i = 0; i < similarities.length; ++i) {
-      std::string label = (subject_id_lut[ids.ids[i]] == subject_id ? "G" : "I");
-      fprintf(cand_list, ",%f(%s)", similarities.similarities[i], label.c_str());
+
+    // Initialize the API
+    // TODO: Right now we only allow a single GPU to be used
+    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1))
+
+    JaniceDetectionPolicy policy = JaniceDetectAll; // This is ignored
+    uint32_t min_object_size = 0;
+    JaniceEnrollmentType role = Janice1NProbe; // This is ignored
+    double hint = 0.0;
+
+    JaniceContext context = nullptr;
+    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, num_returns, hint, &context))
+
+    JaniceGallery gallery = nullptr;
+    { // Create an empty gallery
+        JaniceTemplates tmpls;
+        tmpls.tmpls = nullptr;
+        tmpls.length = 0;
+
+        JaniceTemplateIds ids;
+        ids.ids = nullptr;
+        ids.length = 0;
+        JANICE_ASSERT(janice_create_gallery(tmpls, ids, &gallery))
     }
+
+    // Load the gallery
+    io::CSVReader<3> gallery_metadata(gallery_file);
+    gallery_metadata.read_header(io::ignore_extra_column, "file", "templateId", "subjectId");
+
+    std::unordered_map<int, int> subject_id_lut;
+
+    // Load template into a gallery
+    std::string filename;
+    int template_id, subject_id;
+    while (gallery_metadata.read_row(filename, template_id, subject_id)) {
+        JaniceTemplate tmpl;
+        JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl))
+
+        JANICE_ASSERT(janice_gallery_insert(gallery, tmpl, template_id))
+
+        subject_id_lut[template_id] = subject_id;
+
+        JANICE_ASSERT(janice_free_template(&tmpl))
+    }
+
+    // Keep
+    const uint32_t k = num_returns != 0 ? std::min(num_returns, (uint32_t) subject_id_lut.size()) : (uint32_t) subject_id_lut.size();
+
+    // Open the candidate list file
+    printf("cand_list_file: %s\n", cand_list_file.c_str());
+    FILE* cand_list = fopen(cand_list_file.c_str(), "w+");
+    fprintf(cand_list, "0");
+    for (uint32_t i = 0; i < k; ++i)
+        fprintf(cand_list, ",%u", i);
     fprintf(cand_list, "\n");
-    
-    JANICE_ASSERT(janice_clear_similarities(&similarities));
-    JANICE_ASSERT(janice_clear_template_ids(&ids));
-    JANICE_ASSERT(janice_free_template(&tmpl));
-  }
-  
-  JANICE_ASSERT(janice_free_gallery(&gallery));
-  JANICE_ASSERT(janice_free_context(&context));
-  
-  JANICE_ASSERT(janice_finalize());
-  
-  return 0;
+
+    // Parse the probe file
+    io::CSVReader<3> probe_metadata(probe_file);
+    probe_metadata.read_header(io::ignore_extra_column, "file", "templateId", "subjectId");
+
+    while (probe_metadata.read_row(filename, template_id, subject_id)) {
+        JaniceTemplate tmpl;
+        JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl))
+
+        JaniceSimilarities similarities;
+        JaniceTemplateIds ids;
+        JANICE_ASSERT(janice_search(tmpl, gallery, context, &similarities, &ids))
+
+        fprintf(cand_list, "%d", template_id);
+        for (size_t i = 0; i < similarities.length; ++i) {
+            std::string label = (subject_id_lut[ids.ids[i]] == subject_id ? "G" : "I");
+            fprintf(cand_list, ",%f(%s)", similarities.similarities[i], label.c_str());
+        }
+        fprintf(cand_list, "\n");
+
+        JANICE_ASSERT(janice_clear_similarities(&similarities))
+        JANICE_ASSERT(janice_clear_template_ids(&ids))
+        JANICE_ASSERT(janice_free_template(&tmpl))
+    }
+
+    JANICE_ASSERT(janice_free_gallery(&gallery))
+    JANICE_ASSERT(janice_free_context(&context))
+
+    JANICE_ASSERT(janice_finalize())
+
+    return 0;
 }

--- a/harness/janice_verify.cpp
+++ b/harness/janice_verify.cpp
@@ -2,6 +2,13 @@
 #include <janice_io_opencv.h>
 #include <janice_harness.h>
 
+#include <map>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
 #include <fast-cpp-csv-parser/csv.h>
 
 void print_usage()
@@ -9,36 +16,106 @@ void print_usage()
     printf("Usage: janice_verify sdk_path temp_path templates_list_file_a templates_list_file_b scores_file [-algorithm <algorithm>] [-threads <int>] [-gpu <int>]\n");
 }
 
+static JaniceError janice_load_template_map_from_file(const std::string &templates_list_file, std::map<uint32_t,JaniceTemplate> &templates, std::vector<uint32_t> &template_ids, std::vector<uint32_t> &subject_ids)
+{
+  clock_t start;
+
+  std::ifstream templates_list_stream(templates_list_file.c_str());
+  std::string line;
+
+  while (getline(templates_list_stream, line)) {
+    std::stringstream row(line);
+    std::string template_id, subject_id, template_file;
+    getline(row, template_id, ',');
+    getline(row, subject_id, ',');
+    getline(row, template_file, ',');
+
+    std::stringstream ss;
+    ss << template_id;
+    uint32_t tid;
+    ss >> tid;
+
+    template_ids.push_back(tid);
+    subject_ids.push_back(atoi(subject_id.c_str()));
+
+    if (templates.find(tid) == templates.end()) {
+      // Load the serialized template from disk
+      std::cout << "[" << __func__ << "] deserializing " << template_id << ": " << template_file << std::endl;
+      JaniceTemplate tmpl;
+      JANICE_ASSERT(janice_read_template(template_file.c_str(), &tmpl));
+      templates[tid] = tmpl;
+    }
+  }
+  templates_list_stream.close();
+
+  return JANICE_SUCCESS;
+}
+
 int main(int argc, char* argv[])
 {
-    const int min_args = 6;
-    const int max_args = 12;
+  const int min_args = 6;
+  const int max_args = 12;
 
-    if (argc < min_args || argc > max_args) {
-        print_usage();
-        exit(EXIT_FAILURE);
-    }
+  if (argc < min_args || argc > max_args) {
+    print_usage();
+    exit(EXIT_FAILURE);
+  }
 
-    const std::string sdk_path       = argv[1];
-    const std::string temp_path      = argv[2];
-    const std::string templates_a_path = argv[3];
-    const std::string templates_b_path = argv[4];
-    const std::string scores         = argv[5];
+  const std::string sdk_path       = argv[1];
+  const std::string temp_path      = argv[2];
+  const std::string templates_a_path = argv[3];
+  const std::string templates_b_path = argv[4];
+  const std::string scores         = argv[5];
 
-    std::string algorithm;
-    int num_threads;
-    int gpu;
-    if (!parse_optional_args(argc, argv, min_args, max_args, algorithm, num_threads, gpu)) {
-      exit(EXIT_FAILURE);
-    }
+  std::string algorithm;
+  int num_threads;
+  int gpu;
+  if (!parse_optional_args(argc, argv, min_args, max_args, algorithm, num_threads, gpu)) {
+    exit(EXIT_FAILURE);
+  }
+
+  std::map<uint32_t, JaniceTemplate> templates_a;
+  std::map<uint32_t, JaniceTemplate> templates_b;
+  std::vector<uint32_t> template_ids_a;
+  std::vector<uint32_t> template_ids_b;
+  std::vector<uint32_t> subject_ids_a;
+  std::vector<uint32_t> subject_ids_b;
+
+  JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
+
+  JANICE_ASSERT(janice_load_template_map_from_file(templates_a_path, templates_a, template_ids_a, subject_ids_a));
+  JANICE_ASSERT(janice_load_template_map_from_file(templates_b_path, templates_b, template_ids_b, subject_ids_b));
     
-    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
-    JaniceTemplates templates_a;
-    memset(&templates_a, '\0', sizeof(templates_a));
-    JaniceTemplates templates_b;
-    memset(&templates_b, '\0', sizeof(templates_b));
-    // TODO: Read template files. Figure out how to handle template IDs--presumably in templates list
-    // file, but not in templates themselves, so we have to maintain parallel structures for those.
-    JANICE_ASSERT(janice_finalize());
-    exit(1);
+  assert(templates.a.size() == templates.b.size());
+
+  std::ofstream scores_stream(scores.c_str(), std::ios::out | std::ios::ate);
+  scores_stream.precision(15);
+  scores_stream << "TEMPLATE_ID1,TEMPLATE_ID2,ERROR_CODE,SCORE,VERIFY_TIME" << std::endl;
+  for (size_t i = 0; i < template_ids_a.size(); ++i) {
+    uint32_t tid_a = template_ids_a[i];
+    uint32_t tid_b = template_ids_b[i];
+      
+    JaniceSimilarity similarity;
+    JaniceTemplate template_a = templates_a[tid_a];
+    JaniceTemplate template_b = templates_b[tid_b];
+
+    JaniceError res = janice_verify(template_a, template_b, &similarity);
+    scores_stream << tid_a << ","
+                  << tid_b << ","
+                  << res << ","
+                  << similarity << ","
+                  << "0.0" << std::endl;
+  }
+  scores_stream.close();
+  for (auto iter = templates_a.begin(); iter != templates_a.end(); ++iter) {
+    JaniceTemplate tmpl = (*iter).second;
+    janice_free_template(&tmpl);
+  }
+  for (auto iter = templates_b.begin(); iter != templates_b.end(); ++iter) {
+    JaniceTemplate tmpl = (*iter).second;
+    janice_free_template(&tmpl);
+  }
+    
+  JANICE_ASSERT(janice_finalize());
+  exit(1);
 }

--- a/harness/janice_verify.cpp
+++ b/harness/janice_verify.cpp
@@ -1,0 +1,44 @@
+#include <janice.h>
+#include <janice_io_opencv.h>
+#include <janice_harness.h>
+
+#include <fast-cpp-csv-parser/csv.h>
+
+void print_usage()
+{
+    printf("Usage: janice_verify sdk_path temp_path templates_list_file_a templates_list_file_b scores_file [-algorithm <algorithm>] [-threads <int>] [-gpu <int>]\n");
+}
+
+int main(int argc, char* argv[])
+{
+    const int min_args = 6;
+    const int max_args = 12;
+
+    if (argc < min_args || argc > max_args) {
+        print_usage();
+        exit(EXIT_FAILURE);
+    }
+
+    const std::string sdk_path       = argv[1];
+    const std::string temp_path      = argv[2];
+    const std::string templates_a_path = argv[3];
+    const std::string templates_b_path = argv[4];
+    const std::string scores         = argv[5];
+
+    std::string algorithm;
+    int num_threads;
+    int gpu;
+    if (!parse_optional_args(argc, argv, min_args, max_args, algorithm, num_threads, gpu)) {
+      exit(EXIT_FAILURE);
+    }
+    
+    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
+    JaniceTemplates templates_a;
+    memset(&templates_a, '\0', sizeof(templates_a));
+    JaniceTemplates templates_b;
+    memset(&templates_b, '\0', sizeof(templates_b));
+    // TODO: Read template files. Figure out how to handle template IDs--presumably in templates list
+    // file, but not in templates themselves, so we have to maintain parallel structures for those.
+    JANICE_ASSERT(janice_finalize());
+    exit(1);
+}

--- a/implementations/opencv_io/janice_io_opencv.cpp
+++ b/implementations/opencv_io/janice_io_opencv.cpp
@@ -189,11 +189,13 @@ JaniceError tell(JaniceMediaIterator it, uint32_t* frame)
 
 JaniceError free_image(JaniceImage* image)
 {
-    if ((*image)->owner)
-        free((*image)->data);
-    delete (*image);
-
-    return JANICE_SUCCESS;
+  if ((*image)->owner) {
+    free((*image)->data);
+    (*image)->data = nullptr;
+  }
+  delete (*image);
+  *image = nullptr;
+  return JANICE_SUCCESS;
 }
 
 JaniceError free_iterator(JaniceMediaIterator* it)


### PR DESCRIPTION
I changed the harness CMakeLists.txt file to loop over the list of files (just like in the Janus src/utils directory). If JANICE_EVAL_HARNESS_INSTALL is defined, then it will be used as an installation destination for each of the harness executables.
