### PR TITLE
Add semicolons after JANICE_ASSERT calls

### DIFF
--- a/harness/janice_cluster_media.cpp
+++ b/harness/janice_cluster_media.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
 
     // Initialize the API
     // TODO: Right now we only allow a single GPU to be used
-    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1))
+    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
 
     // Unused defaults for context parameters
     JaniceDetectionPolicy policy = JaniceDetectAll;
@@ -52,7 +52,7 @@ int main(int argc, char* argv[])
     JaniceEnrollmentType role = JaniceCluster;
 
     JaniceContext context = nullptr;
-    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context))
+    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context));
 
     // Parse the metadata file
     io::CSVReader<1> metadata(input_file);
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
     media.length = filenames.size();
     media.media  = new JaniceMediaIterator[media.length];
     for( size_t i=0; i < media.length; i++) {
-        JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + "/" + filenames[i]).c_str(), &media.media[i]));
+      JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + "/" + filenames[i]).c_str(), &media.media[i]));
     }
 
     JaniceClusterIdsGroup cluster_ids;
@@ -143,7 +143,7 @@ int main(int argc, char* argv[])
     delete [] media.media;
 
     // Finalize the API
-    JANICE_ASSERT(janice_finalize())
+    JANICE_ASSERT(janice_finalize());
 
     return 0;
 }

--- a/harness/janice_cluster_templates.cpp
+++ b/harness/janice_cluster_templates.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
 
     // Initialize the API
     // TODO: Right now we only allow a single GPU to be used
-    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1))
+    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
 
     // Unused defaults for context parameters
     JaniceDetectionPolicy policy = JaniceDetectAll;
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
     JaniceEnrollmentType role = JaniceCluster;
 
     JaniceContext context = nullptr;
-    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context))
+    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context));
 
     // Parse the metadata file
     io::CSVReader<2> metadata(input_file);
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
     delete [] tmpls.tmpls;
 
     // Finalize the API
-    JANICE_ASSERT(janice_finalize())
+    JANICE_ASSERT(janice_finalize());
 
     return 0;
 }

--- a/harness/janice_detect.cpp
+++ b/harness/janice_detect.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
 
     // Initialize the API
     // TODO: Right now we only allow a single GPU to be used
-    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1))
+    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
 
     // Unused defaults for context parameters
     JaniceEnrollmentType role = Janice1NProbe;
@@ -60,7 +60,7 @@ int main(int argc, char* argv[])
     double hint = 0;
 
     JaniceContext context = nullptr;
-    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context))
+    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context));
 
     // Parse the images file
     io::CSVReader<1> images(images_file);
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
     std::string filename;
     while (images.read_row(filename)) {
         JaniceMediaIterator it;
-        JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &it))
+        JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &it));
 
         filenames.push_back(filename);
         media.push_back(it);
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
 
     // Run batch detection
     JaniceDetectionsGroup detections_group;
-    JANICE_ASSERT(janice_detect_batch(media_list, context, &detections_group))
+    JANICE_ASSERT(janice_detect_batch(media_list, context, &detections_group));
 
     // Assert we got the correct number of detections (1 list for each media)
     if (detections_group.length != media.size()) {
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
 
     // Free the media objects
     for (JaniceMediaIterator& it : media)
-        JANICE_ASSERT(it->free(&it))
+      JANICE_ASSERT(it->free(&it));
     
     // Write the detection files to disk
     FILE* output = fopen(output_file.c_str(), "w+");
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
         JaniceDetections detections = detections_group.group[i];
         for (size_t j = 0; j < detections.length; ++j) {
             JaniceTrack track;
-            JANICE_ASSERT(janice_detection_get_track(detections.detections[j], &track))
+            JANICE_ASSERT(janice_detection_get_track(detections.detections[j], &track));
 
             const std::string filename = filenames[i];
             for (size_t k = 0; k < track.length; ++k) {
@@ -118,15 +118,15 @@ int main(int argc, char* argv[])
             }
 
             // Free the track
-            JANICE_ASSERT(janice_clear_track(&track))
+            JANICE_ASSERT(janice_clear_track(&track));
         }
     }
 
     // Free the detections
-    JANICE_ASSERT(janice_clear_detections_group(&detections_group))
+    JANICE_ASSERT(janice_clear_detections_group(&detections_group));
 
     // Finalize the API
-    JANICE_ASSERT(janice_finalize())
+    JANICE_ASSERT(janice_finalize());
 
     return 0;
 }

--- a/harness/janice_enroll_detections.cpp
+++ b/harness/janice_enroll_detections.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
 
     // Initialize the API
     // TODO: Right now we only allow a single GPU to be used
-    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1))
+    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
 
     // Unused defaults for context parameters
     JaniceDetectionPolicy policy = JaniceDetectAll;
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
     double hint = 0;
 
     JaniceContext context = nullptr;
-    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context))
+    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context));
 
     // Parse the metadata file
     io::CSVReader<7> metadata(input_file);
@@ -78,10 +78,10 @@ int main(int argc, char* argv[])
     JaniceRect rect;
     while (metadata.read_row(filename, template_id, subject_id, rect.x, rect.y, rect.width, rect.height)) {
         JaniceMediaIterator media;
-        JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &media))
+        JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &media));
 
         JaniceDetection detection;
-        JANICE_ASSERT(janice_create_detection_from_rect(media, rect, 0, &detection))
+        JANICE_ASSERT(janice_create_detection_from_rect(media, rect, 0, &detection));
 
         if (detections_lut.find(template_id) == detections_lut.end()) {
             detections_lut.insert(std::make_pair(template_id, std::vector<JaniceDetection>{detection}));
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
 
         subject_id_lut[template_id] = subject_id;
 
-        JANICE_ASSERT(media->free(&media))
+        JANICE_ASSERT(media->free(&media));
     }
 
     // Convert the LUT into a detections group object
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
 
     // Run batch enrollment
     JaniceTemplates tmpls;
-    JANICE_ASSERT(janice_enroll_from_detections_batch(detections_group, context, &tmpls))
+    JANICE_ASSERT(janice_enroll_from_detections_batch(detections_group, context, &tmpls));
 
     // Assert we got the correct number of templates (1 list for each media)
     if (tmpls.length != detections_group.length) {
@@ -125,7 +125,7 @@ int main(int argc, char* argv[])
     // Clear the detections
     for (size_t i = 0; i < detections_group.length; ++i) {
         for (size_t j = 0; j < detections_group.group[i].length; ++j)
-            JANICE_ASSERT(janice_free_detection(&detections_group.group[i].detections[j]));
+          JANICE_ASSERT(janice_free_detection(&detections_group.group[i].detections[j]));
         delete[] detections_group.group[i].detections;
     }
     delete[] detections_group.group;
@@ -136,16 +136,16 @@ int main(int argc, char* argv[])
 
     for (size_t i = 0; i < tmpls.length; ++i) {
         std::string tmpl_file = output_path + "/" + std::to_string(template_ids[i]) + ".tmpl";
-        JANICE_ASSERT(janice_write_template(tmpls.tmpls[i], tmpl_file.c_str()))
+        JANICE_ASSERT(janice_write_template(tmpls.tmpls[i], tmpl_file.c_str()));
 
         fprintf(output, "%s,%d,%d\n", tmpl_file.c_str(), template_ids[i], subject_id_lut[template_ids[i]]);
     }
 
     // Free the templates
-    JANICE_ASSERT(janice_clear_templates(&tmpls))
+    JANICE_ASSERT(janice_clear_templates(&tmpls));
 
     // Finalize the API
-    JANICE_ASSERT(janice_finalize())
+    JANICE_ASSERT(janice_finalize());
 
     return 0;
 }

--- a/harness/janice_enroll_media.cpp
+++ b/harness/janice_enroll_media.cpp
@@ -66,7 +66,7 @@ int main(int argc, char* argv[])
 
     // Initialize the API
     // TODO: Right now we only allow a single GPU to be used
-    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1))
+    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
 
     // Unused defaults for context parameters
     double threshold = 0;
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
     double hint = 0;
 
     JaniceContext context = nullptr;
-    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context))
+    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, max_returns, hint, &context));
 
     // Parse the metadata file
     io::CSVReader<1> metadata(input_file);
@@ -87,7 +87,7 @@ int main(int argc, char* argv[])
     std::string filename;
     while (metadata.read_row(filename)) {
         JaniceMediaIterator it;
-        JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &it))
+        JANICE_ASSERT(janice_io_opencv_create_media_iterator((std::string(data_path) + filename).c_str(), &it));
 
         filenames.push_back(filename);
         media.push_back(it);
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
     // Run batch enrollment
     JaniceTemplatesGroup tmpls_group;
     JaniceTracksGroup    tracks_group;
-    JANICE_ASSERT(janice_enroll_from_media_batch(media_list, context, &tmpls_group, &tracks_group))
+    JANICE_ASSERT(janice_enroll_from_media_batch(media_list, context, &tmpls_group, &tracks_group));
 
     // Assert we got the correct number of templates (1 list for each media)
     if (tmpls_group.length != media.size()) {
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
 
     // Free the media objects
     for (JaniceMediaIterator& it : media)
-        JANICE_ASSERT(it->free(&it))
+      JANICE_ASSERT(it->free(&it));
     
     // Write the templates to disk
     FILE* output = fopen((output_path + "/templates.csv").c_str(), "w+");
@@ -141,13 +141,13 @@ int main(int argc, char* argv[])
     }
 
     // Clean up
-    JANICE_ASSERT(janice_clear_templates_group(&tmpls_group))
-    JANICE_ASSERT(janice_clear_tracks_group(&tracks_group))
+    JANICE_ASSERT(janice_clear_templates_group(&tmpls_group));
+    JANICE_ASSERT(janice_clear_tracks_group(&tracks_group));
 
-    JANICE_ASSERT(janice_free_context(&context))
+    JANICE_ASSERT(janice_free_context(&context));
 
     // Finalize the API
-    JANICE_ASSERT(janice_finalize())
+    JANICE_ASSERT(janice_finalize());
 
     return 0;
 }

--- a/harness/janice_search.cpp
+++ b/harness/janice_search.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[])
 
     // Initialize the API
     // TODO: Right now we only allow a single GPU to be used
-    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1))
+    JANICE_ASSERT(janice_initialize(sdk_path.c_str(), temp_path.c_str(), algorithm.c_str(), num_threads, &gpu, 1));
 
     JaniceDetectionPolicy policy = JaniceDetectAll; // This is ignored
     uint32_t min_object_size = 0;
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
     double hint = 0.0;
 
     JaniceContext context = nullptr;
-    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, num_returns, hint, &context))
+    JANICE_ASSERT(janice_create_context(policy, min_object_size, role, threshold, num_returns, hint, &context));
 
     JaniceGallery gallery = nullptr;
     { // Create an empty gallery
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
         JaniceTemplateIds ids;
         ids.ids = nullptr;
         ids.length = 0;
-        JANICE_ASSERT(janice_create_gallery(tmpls, ids, &gallery))
+        JANICE_ASSERT(janice_create_gallery(tmpls, ids, &gallery));
     }
 
     // Load the gallery
@@ -81,13 +81,13 @@ int main(int argc, char* argv[])
     int template_id, subject_id;
     while (gallery_metadata.read_row(filename, template_id, subject_id)) {
         JaniceTemplate tmpl;
-        JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl))
+        JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl));
 
-        JANICE_ASSERT(janice_gallery_insert(gallery, tmpl, template_id))
+        JANICE_ASSERT(janice_gallery_insert(gallery, tmpl, template_id));
 
         subject_id_lut[template_id] = subject_id;
 
-        JANICE_ASSERT(janice_free_template(&tmpl))
+        JANICE_ASSERT(janice_free_template(&tmpl));
     }
 
     // Keep
@@ -107,11 +107,11 @@ int main(int argc, char* argv[])
 
     while (probe_metadata.read_row(filename, template_id, subject_id)) {
         JaniceTemplate tmpl;
-        JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl))
+        JANICE_ASSERT(janice_read_template(filename.c_str(), &tmpl));
 
         JaniceSimilarities similarities;
         JaniceTemplateIds ids;
-        JANICE_ASSERT(janice_search(tmpl, gallery, context, &similarities, &ids))
+        JANICE_ASSERT(janice_search(tmpl, gallery, context, &similarities, &ids));
 
         fprintf(cand_list, "%d", template_id);
         for (size_t i = 0; i < similarities.length; ++i) {
@@ -120,15 +120,15 @@ int main(int argc, char* argv[])
         }
         fprintf(cand_list, "\n");
 
-        JANICE_ASSERT(janice_clear_similarities(&similarities))
-        JANICE_ASSERT(janice_clear_template_ids(&ids))
-        JANICE_ASSERT(janice_free_template(&tmpl))
+        JANICE_ASSERT(janice_clear_similarities(&similarities));
+        JANICE_ASSERT(janice_clear_template_ids(&ids));
+        JANICE_ASSERT(janice_free_template(&tmpl));
     }
 
-    JANICE_ASSERT(janice_free_gallery(&gallery))
-    JANICE_ASSERT(janice_free_context(&context))
+    JANICE_ASSERT(janice_free_gallery(&gallery));
+    JANICE_ASSERT(janice_free_context(&context));
 
-    JANICE_ASSERT(janice_finalize())
+    JANICE_ASSERT(janice_finalize());
 
     return 0;
 }


### PR DESCRIPTION
Added semicolons after JANICE_ASSERT where they were missing (not everywhere), alas. It's good to be consistent, and it's good for the syntax to be visually correct.