### PR TITLE
Allow suppression of harness executables builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,4 +41,7 @@ add_subdirectory(interfaces)
 add_subdirectory(implementations)
 
 # Optionally build the test harness
-add_subdirectory(harness)
+if(NOT JANICE_SKIP_HARNESS)
+  add_subdirectory(harness)
+endif()
+


### PR DESCRIPTION
Added a test to suppress compilation of the harness executables. It's convenient to add the entire janice submodule to the component (detection, clustering) builds, but in that case one doesn't want to build a lot of stuff that won't work. If JANICE_SKIP_HARNESS is false (or not set, the equivalent), then the harness executables will be built, as usual; if it's true, then they won't be.