### PR TITLE
Clear image data pointers after free, so any subsequent calls won't die

### DIFF
--- a/implementations/memory_io/janice_io_memory.cpp
+++ b/implementations/memory_io/janice_io_memory.cpp
@@ -87,6 +87,7 @@ JaniceError free_image(JaniceImage* image)
 {
     if (image && image->owner) {
         free(image->data);
+        image->data = nullptr;
     }
 
     return JANICE_SUCCESS;

--- a/implementations/memory_io/janice_io_memory_sparse.cpp
+++ b/implementations/memory_io/janice_io_memory_sparse.cpp
@@ -97,6 +97,7 @@ JaniceError free_image(JaniceImage* image)
 {
     if (image && image->owner) {
         free(image->data);
+        image->data = nullptr;
     }
 
     return JANICE_SUCCESS;

--- a/implementations/opencv_io/janice_io_opencv.cpp
+++ b/implementations/opencv_io/janice_io_opencv.cpp
@@ -237,6 +237,7 @@ JaniceError free_image(JaniceImage* image)
 {
     if (image && image->owner) {
         free(image->data);
+        image->data = nullptr;
     }
 
     return JANICE_SUCCESS;

--- a/implementations/opencv_io/janice_io_opencv_sparse.cpp
+++ b/implementations/opencv_io/janice_io_opencv_sparse.cpp
@@ -115,6 +115,7 @@ JaniceError free_image(JaniceImage* image)
 {
     if (image && image->owner) {
         free(image->data);
+        image->data = nullptr;
     }
 
     return JANICE_SUCCESS;


### PR DESCRIPTION
This makes it somewhat safer to use stack-allocated JaniceImage objects: free_image() on a stack-allocated image should leave the object in a state where another free_image() won't crash. Makes it easier for functions to clean up after themselves.