### PR TITLE
Avert some memory leaks with JaniceErrors: ensure they're empty befor…

### DIFF
--- a/harness/janice_detect.cpp
+++ b/harness/janice_detect.cpp
@@ -112,12 +112,14 @@ int main(int argc, char* argv[])
         // Run batch detection
         JaniceDetectionsGroup detections_group;
         JaniceErrors batch_errors;
+        memset(&batch_errors, '\0', sizeof(batch_errors));
 
         auto start = std::chrono::high_resolution_clock::now();
         JaniceError ret = janice_detect_batch(&media_list, &context, &detections_group, &batch_errors);
         double elapsed = 10e-3 * std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start).count();
 
         if (ret == JANICE_BATCH_FINISHED_WITH_ERRORS) {
+            bool doExit = false;
             for (size_t err_idx = 0; err_idx < batch_errors.length; ++err_idx) {
                 JaniceError e = batch_errors.errors[err_idx];
                 if (e != JANICE_SUCCESS) {
@@ -127,11 +129,16 @@ int main(int argc, char* argv[])
                               << "    Location: " << __FILE__ << ":" << __LINE__ << std::endl;
 
                     if (ignored_errors.find(e) != ignored_errors.end()) {
-                        exit(EXIT_FAILURE);
+                        doExit = true;
                     }
                 }
             }
+            if (doExit) {
+                exit(EXIT_FAILURE);
+            }
         }
+
+        janice_clear_errors(&batch_errors);
 
         // Assert we got the correct number of detections (1 list for each media)
         if (detections_group.length != current_batch_size) {

--- a/harness/janice_enroll_detections.cpp
+++ b/harness/janice_enroll_detections.cpp
@@ -193,12 +193,14 @@ int main(int argc, char* argv[])
 
         JaniceTemplates tmpls;
         JaniceErrors batch_errors;
+        memset(&batch_errors, '\0', sizeof(batch_errors));
 
         auto start = std::chrono::high_resolution_clock::now();
         JaniceError ret = janice_enroll_from_detections_batch(&media_group, &detections_group, &context, &tmpls, &batch_errors);
         double elapsed = 10e-3 * std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start).count();
 
         if (ret == JANICE_BATCH_FINISHED_WITH_ERRORS) {
+            bool doExit = false;
             for (size_t err_idx = 0; err_idx < batch_errors.length; ++err_idx) {
                 JaniceError e = batch_errors.errors[err_idx];
                 if (e != JANICE_SUCCESS) {
@@ -208,11 +210,16 @@ int main(int argc, char* argv[])
                               << "    Location: " << __FILE__ << ":" << __LINE__ << std::endl;
 
                     if (ignored_errors.find(e) != ignored_errors.end()) {
-                        exit(EXIT_FAILURE);
+                        doExit = true;
                     }
                 }
             }
+            if (doExit) {
+                exit(EXIT_FAILURE);
+            }
         }
+
+        janice_clear_errors(&batch_errors);
 
         // Assert we got the correct number of templates (1 tmpl per detection subgroup)
         if (tmpls.length != current_batch_size) {

--- a/harness/janice_search.cpp
+++ b/harness/janice_search.cpp
@@ -108,12 +108,14 @@ int main(int argc, char* argv[])
         JaniceSimilaritiesGroup search_scores;
         JaniceTemplateIdsGroup search_ids;
         JaniceErrors batch_errors;
+        memset(&batch_errors, '\0', sizeof(batch_errors));
 
         auto start = std::chrono::high_resolution_clock::now();
         JaniceError ret = janice_search_batch(&probes, gallery, &context, &search_scores, &search_ids, &batch_errors);
         double elapsed = 10e-3 * std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start).count();
 
         if (ret == JANICE_BATCH_FINISHED_WITH_ERRORS) {
+            bool doExit = false;
             for (size_t err_idx = 0; err_idx < batch_errors.length; ++err_idx) {
                 JaniceError e = batch_errors.errors[err_idx];
                 if (e != JANICE_SUCCESS) {
@@ -123,11 +125,16 @@ int main(int argc, char* argv[])
                               << "    Location: " << __FILE__ << ":" << __LINE__ << std::endl;
 
                     if (ignored_errors.find(e) != ignored_errors.end()) {
-                        exit(EXIT_FAILURE);
+                        doExit = true;
                     }
                 }
             }
+            if (doExit) {
+                exit(EXIT_FAILURE);
+            }
         }
+
+        janice_clear_errors(&batch_errors);
 
         for (int probe_idx = 0; probe_idx < current_batch_size; ++probe_idx) {
             for (int search_idx = 0; search_idx < search_scores.group[probe_idx].length; ++search_idx) {


### PR DESCRIPTION
…e use, and that they get cleared after use.
In the test harness executables that use JaniceErrors structs, make sure they're zeroed out before they get used. The callee could do that, but it's better to be sure that we're in a good state.
In addition, the JaniceErrors structures were not getting cleared on return, so would leak memory.
Finally, change the loop that reports the errors in the struct so it reports *all* the errors before (possibly) exiting.
